### PR TITLE
[Feature/apit-endpoints-implementation] Implemented listing, search, filtering, pagination functionalities

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
     "dotenv": "^16.3.1",
     "mssql": "^9.1.1",
     "reflect-metadata": "^0.1.13",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_PAGE_SIZE = 10;
+export const DEFAULT_PAGE = 1;

--- a/src/database/entities/pokemon.entity.ts
+++ b/src/database/entities/pokemon.entity.ts
@@ -16,7 +16,7 @@ class PokemonEntity extends BaseEntity {
   generation: number;
 
   @Column({ nullable: true })
-  evolutionStage: string | null;
+  evolutionStage!: string;
 
   @Column()
   hasEvolved: boolean;
@@ -34,13 +34,13 @@ class PokemonEntity extends BaseEntity {
   type1: string;
 
   @Column({ nullable: true })
-  type2: string | null;
+  type2!: string;
 
   @Column()
   weather1: string;
 
   @Column({ nullable: true })
-  weather2: string | null;
+  weather2!: string;
 
   @Column()
   totalStats: number;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,16 @@
 import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
+import { AppModule } from './modules/app/app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      transformOptions: { enableImplicitConversion: true },
+      forbidNonWhitelisted: true,
+    }),
+  );
   await app.listen(8080);
 }
 bootstrap();

--- a/src/modules/app/app.controller.ts
+++ b/src/modules/app/app.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class AppController {
+  @Get()
+  home() {
+    return `
+        Welcome to the Pokemon Go Searchbase CRUD Application!
+        This application allows you to explore and manage Pokemon data. 
+
+        You can perform various operations such as listing all Pokemon, 
+        searching for specific Pokemon, filtering them based on types and rarity,
+        and navigating through paginated results.`;
+  }
+}

--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
-import DatabaseConfigOptions from './database/database.config';
-import { SeederModule } from './database/seeders/seeder.module';
+import DatabaseConfigOptions from '../..//database/database.config';
+import { SeederModule } from '../../database/seeders/seeder.module';
+import { PokemonModule } from '../pokemon/pokemon.module';
+import { AppController } from './app.controller';
 
 @Module({
   imports: [
@@ -12,8 +14,9 @@ import { SeederModule } from './database/seeders/seeder.module';
       envFilePath: ['.env'],
     }),
     SeederModule,
+    PokemonModule,
   ],
-  controllers: [],
+  controllers: [AppController],
   providers: [],
 })
 export class AppModule {}

--- a/src/modules/pokemon/dto/index.ts
+++ b/src/modules/pokemon/dto/index.ts
@@ -1,0 +1,37 @@
+import {
+  IsBoolean,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsString,
+} from 'class-validator';
+import { PokemonType, PokemonWeather } from '../types';
+
+export class PokemonListQueryParams {
+  @IsString()
+  @IsOptional()
+  q?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  pagination?: boolean;
+
+  @IsPositive()
+  @IsNumber()
+  @IsOptional()
+  page?: number;
+
+  @IsPositive()
+  @IsNumber({}, { each: true })
+  @IsOptional()
+  page_size?: number;
+
+  @IsOptional()
+  @IsEnum(PokemonType)
+  type?: PokemonType;
+
+  @IsOptional()
+  @IsEnum(PokemonWeather)
+  weather?: PokemonWeather;
+}

--- a/src/modules/pokemon/pokemon.controller.ts
+++ b/src/modules/pokemon/pokemon.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { PokemonService } from './pokemon.service';
+import { PokemonListQueryParams } from './dto';
+
+@Controller('pokemons')
+export class PokemonController {
+  constructor(private readonly pokemonService: PokemonService) {}
+
+  @Get()
+  async getPokemonsList(@Query() query?: PokemonListQueryParams) {
+    return await this.pokemonService.getPokemonsList(query);
+  }
+
+  @Get('/:id')
+  async getPokemon(@Param('id') pokemonId: string) {
+    return await this.pokemonService.getPokemon(pokemonId);
+  }
+}

--- a/src/modules/pokemon/pokemon.module.ts
+++ b/src/modules/pokemon/pokemon.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { PokemonService } from './pokemon.service';
+import { PokemonController } from './pokemon.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import PokemonEntity from 'src/database/entities/pokemon.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([PokemonEntity])],
+  controllers: [PokemonController],
+  providers: [PokemonService],
+  exports: [],
+})
+export class PokemonModule {}

--- a/src/modules/pokemon/pokemon.service.ts
+++ b/src/modules/pokemon/pokemon.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from 'src/constants';
+import PokemonEntity from 'src/database/entities/pokemon.entity';
+import { PaginatedResult } from 'src/shared/types';
+import { Like, Repository } from 'typeorm';
+import { PokemonListQueryParams } from './dto';
+
+@Injectable()
+export class PokemonService {
+  constructor(
+    @InjectRepository(PokemonEntity)
+    private readonly pokemonRepository: Repository<PokemonEntity>,
+  ) {}
+
+  async getPokemonsList(
+    query?: PokemonListQueryParams,
+  ): Promise<PokemonEntity[] | PaginatedResult<PokemonEntity>> {
+    const searchQuery = query?.q || '';
+    const findOptions: Record<string, number | Array<unknown>> = {
+      where: [
+        { name: Like(`%${searchQuery}%`) },
+        { pokedexId: Like(`%${searchQuery}%`) },
+        query?.type && { type1: query?.type },
+        query?.type && { type2: query?.type },
+        query?.weather && { weather1: query?.weather },
+        query?.weather && { weather2: query?.weather },
+      ],
+    };
+
+    const pagination = query?.pagination;
+    if (pagination) {
+      findOptions.take = query?.page_size ?? DEFAULT_PAGE_SIZE;
+
+      const page = query?.page ?? DEFAULT_PAGE;
+      findOptions.skip = (page - 1) * findOptions.take;
+
+      const [results, count] = await this.pokemonRepository.findAndCount(
+        findOptions,
+      );
+
+      return {
+        results,
+        count,
+      };
+    }
+
+    return await this.pokemonRepository.find(findOptions);
+  }
+
+  async getPokemon(pokemonId: string) {
+    return await this.pokemonRepository.findOne({ where: { id: pokemonId } });
+  }
+}

--- a/src/modules/pokemon/types.ts
+++ b/src/modules/pokemon/types.ts
@@ -1,0 +1,32 @@
+
+export enum PokemonType {
+  GRASS = 'grass',
+  FIRE = 'fire',
+  WATER = 'water',
+  BUG = 'bug',
+  NORMAL = 'normal',
+  POISON = 'poison',
+  ELECTRIC = 'electric',
+  GROUND = 'ground',
+  FAIRY = 'fairy',
+  FIGHTING = 'fighting',
+  PSYCHIC = 'psychic',
+  ROCK = 'rock',
+  GHOST = 'ghost',
+  ICE = 'ice',
+  DRAGON = 'dragon',
+  DARK = 'dark',
+  STEEL = 'steel',
+  FLYING = 'flying',
+}
+
+export enum PokemonWeather {
+  SUNNY = 'Sunny/Clear',
+  RAINY = 'Rainy',
+  PARTLY = 'Partly Cloudy',
+  CLOUDY = 'Cloudy',
+  WINDY = 'Windy',
+  FOG = 'Fog',
+  SNOW = 'Snow',
+}
+

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,0 +1,4 @@
+export interface PaginatedResult<T> {
+  count: number;
+  results: Array<T>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1248,6 +1248,11 @@
   dependencies:
     "@types/superagent" "*"
 
+"@types/validator@^13.7.10":
+  version "13.9.0"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.9.0.tgz#e7a96da3ea6a936222c6e76bb54abdd3dc4c9e4a"
+  integrity sha512-NclP0IbzHj/4tJZKFqKh8E7kZdgss+MCUYV9G+TLltFfDA4lFgE4PKPpDIyS2FlcdANIfSx273emkupvChigbw==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
@@ -1978,6 +1983,20 @@ cjs-module-lexer@^1.0.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz#6c370ab19f8a3394e318fe682686ec0ac684d107"
   integrity sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==
+
+class-transformer@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.5.1.tgz#24147d5dffd2a6cea930a3250a677addf96ab336"
+  integrity sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==
+
+class-validator@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/class-validator/-/class-validator-0.14.0.tgz#40ed0ecf3c83b2a8a6a320f4edb607be0f0df159"
+  integrity sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==
+  dependencies:
+    "@types/validator" "^13.7.10"
+    libphonenumber-js "^1.10.14"
+    validator "^13.7.0"
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -4040,6 +4059,11 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+libphonenumber-js@^1.10.14:
+  version "1.10.39"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.10.39.tgz#12dd512621c9ebb13402a694ac81dc78511cd982"
+  integrity sha512-iPMM/NbSNIrdwbr94rAOos6krB7snhfzEptmk/DJUtTPs+P9gOhZ1YXVPcRgjpp3jJByclfm/Igvz45spfJK7g==
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -5610,6 +5634,11 @@ v8-to-istanbul@^9.0.1:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
+
+validator@^13.7.0:
+  version "13.11.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.11.0.tgz#23ab3fd59290c61248364eabf4067f04955fbb1b"
+  integrity sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This PR adds multiple features to the PokemonGo backend API as follows:
- Added a new listing endpoint to fetch a paginated list of Pokemon.
- Implemented the ability to search for Pokemon by name or Pokedex ID.
- Included filtering options to search for Pokemon by type or weather condition.
- Implemented pagination to retrieve Pokemon in smaller batches for easier navigation.
- Added a new endpoint to fetch a specific Pokemon by its ID.